### PR TITLE
CRAN build check scripts added

### DIFF
--- a/inst/extras/build.cran.sh
+++ b/inst/extras/build.cran.sh
@@ -1,0 +1,12 @@
+# For info on Travis R scripts, see
+# http://jtleek.com/protocols/travis_bioc_devel/
+
+# Roxygen tips:
+# http://r-pkgs.had.co.nz/man.html
+
+#/usr/local/bin/R CMD BATCH document.R
+/usr/local/bin/R CMD build ../../  --no-build-vignettes
+/usr/local/bin/R CMD check --as-cran ogdindiar_0.0.0.9003.tar.gz --no-build-vignettes
+/usr/local/bin/R CMD INSTALL ogdindiar_0.0.0.9003.tar.gz
+#/usr/local/bin/R CMD BATCH document.R
+

--- a/inst/extras/document.R
+++ b/inst/extras/document.R
@@ -1,0 +1,31 @@
+# Package CRAN release instructions: http://r-pkgs.had.co.nz/release.html
+
+# Documentation, Build and Check
+library(devtools)
+document("../../")
+
+# Examples and unit tests
+# check("../../")
+# run_examples()
+# test() # Run tests
+
+# Submissions:
+# build_win("../../") # Windows check
+# release() # Submit to CRAN
+# submit_cran() # Submit to CRAN without all release() questions
+
+# Utilities:
+#
+# revdep_check("../../")
+# add_rstudio_project("../../")
+# use_build_ignore("../NEWS.md", pkg = "../../") # NEWS.md not supported by CRAN
+# use_package("dplyr") # add package to imports
+# load_all(".") # Reload the package
+
+# Vignettes:
+#
+# library(knitr)
+# knit("../../vignettes/tutorial.Rmd", "../../vignettes/tutorial.md")
+
+
+


### PR DESCRIPTION
I added the ./inst/extras/ directory and two scripts therein:
- document.R : This lists various utilities from the devtools package that can be used from command line to document (with roxygen), test, and finally submit the package to CRAN. Only the roxygen documentation is on, other commands have been commented out. To update documentation, one can run in R: source("document.R"). Probably you are already using some other way to achieve the same but the other utilities listed in this file might be worth exploring.
- build.cran.sh : Run this script on unix command line to check that the package complies with CRAN submission policies. I do not know how to do this with Windows. It is a good idea to use this script (or other means) at a regular basis during package development to make sure that the package stays CRAN-compatible. I run this script with ./build.cran.sh ; the build & check go through but there are some minor issues that I will report separately in the tracker. 
